### PR TITLE
Remove submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/connector_regression"]
-	path = tests/connector_regression
-	url = git@github.com:snowflakedb/snowflake-connector-python


### PR DESCRIPTION
In order to build this package you need access to the `tests/connector_regression` submodule, which requires a github SSH key. We don't need to populate the code from this submodule for our fork, and removing it allows us to build without an SSH key.